### PR TITLE
Add Node exports and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,3 +2,9 @@
 Basic calculator created with HTML, CSS and JS.
 
 [Live Demo](https://ghmacg.github.io/calculator-js/) :point_left:
+
+## Running tests
+
+```bash
+node tests/operations.test.js
+```

--- a/scripts/main.js
+++ b/scripts/main.js
@@ -1,21 +1,23 @@
+const isNode = typeof module !== 'undefined' && module.exports;
+
 let firstNum = '';
 let secondNum = '';
 let currentOperator = null;
 let numSplitted;
 let decimalNum;
 
-const display = document.querySelector('#display');
-const operandBtns = document.querySelectorAll('.operand');
-const operatorBtns = document.querySelectorAll('.operator');
-const equalBtn = document.querySelector('#equals');
-const clearBtn = document.querySelector('#clear');
-const percentageBtn = document.querySelector('#percent');
-const signsBtn = document.querySelector('#sign');
-const decimalBtn = document.querySelector('#decimal');
+const display = !isNode ? document.querySelector('#display') : null;
+const operandBtns = !isNode ? document.querySelectorAll('.operand') : null;
+const operatorBtns = !isNode ? document.querySelectorAll('.operator') : null;
+const equalBtn = !isNode ? document.querySelector('#equals') : null;
+const clearBtn = !isNode ? document.querySelector('#clear') : null;
+const percentageBtn = !isNode ? document.querySelector('#percent') : null;
+const signsBtn = !isNode ? document.querySelector('#sign') : null;
+const decimalBtn = !isNode ? document.querySelector('#decimal') : null;
 
 // Basic math functions
 const add = (x, y) => x + y;
-const substract = (x, y) => x - y;
+const subtract = (x, y) => x - y;
 const multiply = (x, y) => x * y;
 // Evaluate whether or not the user is dividing by 0, in that case return ERROR message 
 const divide = (x, y) => y === 0 ? 'ERROR' : x / y;
@@ -25,7 +27,7 @@ const splitString = (str) => str.toString().replace(/[.-]/g, '').split('');
 // Function to run basic math function depending on operator inputted
 function operate (operator, x, y) {
     firstNum = operator === '+' ? add(x, y) :
-        operator === '-' ? substract(x, y):
+        operator === '-' ? subtract(x, y):
             operator === 'x' ? multiply(x, y):
                 operator === '÷' ? divide(x, y): '';
     // Use toFixed method to round numbers when larger than 8 decimal spaces
@@ -247,4 +249,10 @@ function calculator () {
 
 
 // Function calling
-calculator();
+if (!isNode) {
+    calculator();
+}
+
+if (isNode) {
+    module.exports = { add, subtract, multiply, divide };
+}

--- a/tests/operations.test.js
+++ b/tests/operations.test.js
@@ -1,0 +1,10 @@
+const assert = require('assert');
+const { add, subtract, multiply, divide } = require('../scripts/main.js');
+
+assert.strictEqual(add(1, 2), 3);
+assert.strictEqual(subtract(5, 2), 3);
+assert.strictEqual(multiply(3, 4), 12);
+assert.strictEqual(divide(10, 2), 5);
+assert.strictEqual(divide(1, 0), 'ERROR');
+
+console.log('All tests passed.');


### PR DESCRIPTION
## Summary
- export math helpers from `scripts/main.js` when running under Node
- add automated tests for math functions
- document how to run tests

## Testing
- `node tests/operations.test.js`

------
https://chatgpt.com/codex/tasks/task_e_68405becc884832ba54a3fc8e98c6b08