### PR TITLE
Fix subtract function name

### DIFF
--- a/scripts/main.js
+++ b/scripts/main.js
@@ -15,7 +15,8 @@ const decimalBtn = document.querySelector('#decimal');
 
 // Basic math functions
 const add = (x, y) => x + y;
-const substract = (x, y) => x - y;
+// Corrected spelling of subtract
+const subtract = (x, y) => x - y;
 const multiply = (x, y) => x * y;
 // Evaluate whether or not the user is dividing by 0, in that case return ERROR message 
 const divide = (x, y) => y === 0 ? 'ERROR' : x / y;
@@ -25,7 +26,7 @@ const splitString = (str) => str.toString().replace(/[.-]/g, '').split('');
 // Function to run basic math function depending on operator inputted
 function operate (operator, x, y) {
     firstNum = operator === '+' ? add(x, y) :
-        operator === '-' ? substract(x, y):
+        operator === '-' ? subtract(x, y):
             operator === 'x' ? multiply(x, y):
                 operator === '÷' ? divide(x, y): '';
     // Use toFixed method to round numbers when larger than 8 decimal spaces


### PR DESCRIPTION
## Summary
- correct misspelled `substract` function name
- call the corrected `subtract` in `operate`

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68405bd1da10832b93897538c50191aa