### PR TITLE
Fix bug with undefined variable in calculator

### DIFF
--- a/scripts/main.js
+++ b/scripts/main.js
@@ -62,7 +62,7 @@ function inputOperand (operand) {
     numSplitted = currentOperator === null ? splitString(firstNum) :
         currentOperator !== null ? splitString(secondNum) : '';
         
-    containsExponential = numSplitted.includes('e');
+    let containsExponential = numSplitted.includes('e');
 
     if (currentOperator === null) {
         let firstChar = firstNum.toString().charAt(0);


### PR DESCRIPTION
## Summary
- declare `containsExponential` inside `inputOperand`

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68405a61f150832bad3e341641b37f86